### PR TITLE
Update/#11 order data

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -49,18 +49,6 @@ int main(int argc, char **argv)
     SimpleBLE::ByteArray old_data = "";
     for (;;)
     {
-        // NOTE これで良くね？
-        // std::vector<std::pair<SimpleBLE::BluetoothUUID, SimpleBLE::BluetoothUUID>> uuids;
-        // for (SimpleBLE::Service service : CorBiReader.services())
-        //     for (SimpleBLE::Characteristic characteristic : service.characteristics())
-        //     {
-        //         uuids.push_back(std::make_pair(service.uuid(), characteristic.uuid()));
-        //         for (SimpleBLE::Descriptor descriptor : characteristic.descriptors())
-        //             std::cout << CorBiReader.read(service.uuid(), characteristic.uuid(), descriptor.uuid()) << std::endl; // とりあえず取得テスト
-        //     }
-        // SimpleBLE::ByteArray rx_data = CorBiReader.read(uuids[0].first, uuids[0].second);
-        // SimpleBLE::ByteArray rx_data_RED = CorBiReader.read(uuids[1].first, uuids[1].second);
-        // SimpleBLE::ByteArray rx_data_IR = CorBiReader.read(uuids[2].first, uuids[2].second);
         SimpleBLE::ByteArray rx_data = CorBiReader.read(SERVICE_PULSEOXIMETER_UUID, CHARA_ORDER_UUID);
         SimpleBLE::ByteArray rx_data_RED = CorBiReader.read(SERVICE_PULSEOXIMETER_UUID, CHARA_RED_UUID);
         SimpleBLE::ByteArray rx_data_IR = CorBiReader.read(SERVICE_PULSEOXIMETER_UUID, CHARA_IR_UUID);

--- a/main.cpp
+++ b/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
         return 1;
     if (!CorBiReader.is_connected())
         return 1;
-
+    SimpleBLE::ByteArray old_data = "";
     for (;;)
     {
         std::vector<std::pair<SimpleBLE::BluetoothUUID, SimpleBLE::BluetoothUUID>> uuids;
@@ -50,11 +50,16 @@ int main(int argc, char **argv)
                 uuids.push_back(std::make_pair(service.uuid(), characteristic.uuid()));
 
         SimpleBLE::ByteArray rx_data_IR = CorBiReader.read(uuids[0].first, uuids[0].second);
-        print_byte_array_uint16(rx_data_IR);
-        std::cout << ", ";
         SimpleBLE::ByteArray rx_data_RED = CorBiReader.read(uuids[1].first, uuids[1].second);
-        print_byte_array_int(rx_data_RED);
-        std::cout << std::endl;
+        if (rx_data_RED != old_data)
+        {
+
+            print_byte_array_uint16(rx_data_IR);
+            std::cout << ", ";
+            print_byte_array_int(rx_data_RED);
+            std::cout << std::endl;
+        }
+        old_data = rx_data_RED;
         // print_byte_array_hex(rx_data);
     }
 
@@ -82,7 +87,7 @@ void print_byte_array_uint16(SimpleBLE::ByteArray array)
     for (size_t i = 0; i < array.size(); i += 2)
     {
         uint16_t number = (static_cast<unsigned char>(array[i]) << 8) | static_cast<unsigned char>(array[i + 1]);
-        std::cout << number << " ";
+        std::cout << number << ",";
     }
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -47,16 +47,23 @@ int main(int argc, char **argv)
         std::vector<std::pair<SimpleBLE::BluetoothUUID, SimpleBLE::BluetoothUUID>> uuids;
         for (SimpleBLE::Service service : CorBiReader.services())
             for (SimpleBLE::Characteristic characteristic : service.characteristics())
+            {
                 uuids.push_back(std::make_pair(service.uuid(), characteristic.uuid()));
-
-        SimpleBLE::ByteArray rx_data_IR = CorBiReader.read(uuids[0].first, uuids[0].second);
+                for (SimpleBLE::Descriptor descriptor : characteristic.descriptors())
+                    std::cout << CorBiReader.read(service.uuid(), characteristic.uuid(), descriptor.uuid()) << std::endl; // とりあえず取得テスト
+            }
+        // FIXME サンプルに従ってUUIDを取得する方法にしてたけど、UUID固定してるなら直接指定でも良いかも。
+        SimpleBLE::ByteArray rx_data = CorBiReader.read(uuids[0].first, uuids[0].second);
         SimpleBLE::ByteArray rx_data_RED = CorBiReader.read(uuids[1].first, uuids[1].second);
+        SimpleBLE::ByteArray rx_data_IR = CorBiReader.read(uuids[2].first, uuids[2].second);
         if (rx_data_RED != old_data)
         {
 
             print_byte_array_uint16(rx_data_IR);
-            std::cout << ", ";
+            std::cout << "k, ";
             print_byte_array_int(rx_data_RED);
+            std::cout << "r, ";
+            print_byte_array_int(rx_data);
             std::cout << std::endl;
         }
         old_data = rx_data_RED;

--- a/main.cpp
+++ b/main.cpp
@@ -7,6 +7,11 @@
 
 #define SLEEP_TIME 50 // Java側のバッファ用。初期値：1(ms)
 
+#define SERVICE_PULSEOXIMETER_UUID "c360fb9d-497f-4a0d-bfd3-6cbecd1786e1" // パルスオキシメータ
+#define CHARA_IR_UUID "0c1f518c-ffdf-4b0f-8f2f-ca1edc6dabae"              // 赤外線
+#define CHARA_RED_UUID "1d5b21fa-1a88-4ccb-8be8-9d8f07b0180c"             // 赤色
+#define CHARA_ORDER_UUID "9331cae2-0aec-4a90-a44b-7cde8cbc3257"           // オーダー
+
 void print_byte_array_hex(SimpleBLE::ByteArray array);
 void print_byte_array_float(SimpleBLE::ByteArray array);
 void print_byte_array_uint16(SimpleBLE::ByteArray array);
@@ -44,25 +49,28 @@ int main(int argc, char **argv)
     SimpleBLE::ByteArray old_data = "";
     for (;;)
     {
-        std::vector<std::pair<SimpleBLE::BluetoothUUID, SimpleBLE::BluetoothUUID>> uuids;
-        for (SimpleBLE::Service service : CorBiReader.services())
-            for (SimpleBLE::Characteristic characteristic : service.characteristics())
-            {
-                uuids.push_back(std::make_pair(service.uuid(), characteristic.uuid()));
-                for (SimpleBLE::Descriptor descriptor : characteristic.descriptors())
-                    std::cout << CorBiReader.read(service.uuid(), characteristic.uuid(), descriptor.uuid()) << std::endl; // とりあえず取得テスト
-            }
-        // FIXME サンプルに従ってUUIDを取得する方法にしてたけど、UUID固定してるなら直接指定でも良いかも。
-        SimpleBLE::ByteArray rx_data = CorBiReader.read(uuids[0].first, uuids[0].second);
-        SimpleBLE::ByteArray rx_data_RED = CorBiReader.read(uuids[1].first, uuids[1].second);
-        SimpleBLE::ByteArray rx_data_IR = CorBiReader.read(uuids[2].first, uuids[2].second);
+        // NOTE これで良くね？
+        // std::vector<std::pair<SimpleBLE::BluetoothUUID, SimpleBLE::BluetoothUUID>> uuids;
+        // for (SimpleBLE::Service service : CorBiReader.services())
+        //     for (SimpleBLE::Characteristic characteristic : service.characteristics())
+        //     {
+        //         uuids.push_back(std::make_pair(service.uuid(), characteristic.uuid()));
+        //         for (SimpleBLE::Descriptor descriptor : characteristic.descriptors())
+        //             std::cout << CorBiReader.read(service.uuid(), characteristic.uuid(), descriptor.uuid()) << std::endl; // とりあえず取得テスト
+        //     }
+        // SimpleBLE::ByteArray rx_data = CorBiReader.read(uuids[0].first, uuids[0].second);
+        // SimpleBLE::ByteArray rx_data_RED = CorBiReader.read(uuids[1].first, uuids[1].second);
+        // SimpleBLE::ByteArray rx_data_IR = CorBiReader.read(uuids[2].first, uuids[2].second);
+        SimpleBLE::ByteArray rx_data = CorBiReader.read(SERVICE_PULSEOXIMETER_UUID, CHARA_ORDER_UUID);
+        SimpleBLE::ByteArray rx_data_RED = CorBiReader.read(SERVICE_PULSEOXIMETER_UUID, CHARA_RED_UUID);
+        SimpleBLE::ByteArray rx_data_IR = CorBiReader.read(SERVICE_PULSEOXIMETER_UUID, CHARA_IR_UUID);
         if (rx_data_RED != old_data)
         {
 
             print_byte_array_uint16(rx_data_IR);
-            std::cout << "k, ";
+            std::cout << " ";
             print_byte_array_int(rx_data_RED);
-            std::cout << "r, ";
+            std::cout << " ";
             print_byte_array_int(rx_data);
             std::cout << std::endl;
         }


### PR DESCRIPTION
## 解決するIssue
<!-- このプルリクエストで解決するIssue番号を教えてください。 -->
fix #12 
fix #11 

## 変更内容
<!-- このプルリクエストで変更した内容を教えてください。 -->
UUIDのリストから、Service内のCharacteristicを列挙する方式だった。
これではデータの種類が目的のものと違う場合があった。
↓
CharacteriscitcのUUIDを#defineして、目的のものが固定されるようにした。

## TODO
<!-- このプルリクエストで解決すべきことを教えてください。(e.g., 関係者のレビュー, ユーザテスト, etc.) -->

- [x] Pull Requestを書く

## チェックリスト
<!-- このプルリクエストを発行する前に行ったことを教えてください。必要に応じて、追加してください。 -->

- [x] コード整形をした
- [x] ローカルで動作確認した

## その他
<!-- その他、伝えたいことがあれば教えてください。 -->
データの種類をDescriptorで判別することも考えたのだけど、ループの度にデータの判定を行うことになりそうだったので、処理を軽くするためにやめた。
CorBiReader側に残っている、Descriptorに説明を載せるコードはサードパーティ製品のために残す予定。