### PR TITLE
Estimate heart rate from raw IR samples

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -2,6 +2,10 @@
 #include <iostream>
 #include <thread>
 #include <iomanip>
+#include <deque>
+#include <vector>
+#include <cmath>
+#include <numeric>
 
 #include <simpleble/SimpleBLE.h>
 
@@ -17,15 +21,70 @@ void print_byte_array_float(SimpleBLE::ByteArray array);
 void print_byte_array_uint16(SimpleBLE::ByteArray array);
 void print_byte_array_int(SimpleBLE::ByteArray array);
 SimpleBLE::Peripheral findCorBi(SimpleBLE::Adapter adaper);
+std::vector<uint16_t> decode_uint16_samples(const SimpleBLE::ByteArray &array);
 // TODO 接続周りはコールバックに変更。
 // TODO エラーハンドリングしっかり。
 
 SimpleBLE::Peripheral CorBiReader;
 
+class HeartRateEstimator
+{
+public:
+    void addSamples(const std::vector<uint16_t> &samples)
+    {
+        for (uint16_t sample : samples)
+        {
+            window.push_back(sample);
+            if (window.size() > WINDOW_SIZE)
+                window.pop_front();
+        }
+    }
+
+    double estimateBpm() const
+    {
+        if (window.size() < MIN_WINDOW_SIZE)
+            return 0.0;
+
+        const double mean = std::accumulate(window.begin(), window.end(), 0.0) / window.size();
+        double best_bpm = 0.0;
+        double best_power = 0.0;
+        for (int bpm = MIN_BPM; bpm <= MAX_BPM; bpm++)
+        {
+            const double frequency = bpm / 60.0;
+            double real = 0.0;
+            double imag = 0.0;
+            for (size_t i = 0; i < window.size(); i++)
+            {
+                const double sample = static_cast<double>(window[i]) - mean;
+                const double angle = 2.0 * M_PI * frequency * static_cast<double>(i) / SAMPLE_RATE_HZ;
+                real += sample * std::cos(angle);
+                imag -= sample * std::sin(angle);
+            }
+
+            const double power = real * real + imag * imag;
+            if (power > best_power)
+            {
+                best_power = power;
+                best_bpm = bpm;
+            }
+        }
+        return best_bpm;
+    }
+
+private:
+    static constexpr double SAMPLE_RATE_HZ = 100.0;
+    static constexpr size_t MIN_WINDOW_SIZE = 128;
+    static constexpr size_t WINDOW_SIZE = 256;
+    static constexpr int MIN_BPM = 40;
+    static constexpr int MAX_BPM = 300;
+
+    std::deque<uint16_t> window;
+};
+
 void CorBiCore_exit()
 {
     CorBiReader.disconnect();
-    std::cout << "CorBiCore is exit." << std::endl;
+    std::cerr << "CorBiCore is exit." << std::endl;
 }
 
 int main(int argc, char **argv)
@@ -36,14 +95,14 @@ int main(int argc, char **argv)
 
         if (!SimpleBLE::Adapter::bluetooth_enabled())
         {
-            std::cout << "Bluetooth is not enabled." << std::endl;
+            std::cerr << "Bluetooth is not enabled." << std::endl;
             return 1;
         }
 
         std::vector<SimpleBLE::Adapter> adapters = SimpleBLE::Adapter::get_adapters();
         if (adapters.empty())
         {
-            std::cout << "No BLE adapters found." << std::endl;
+            std::cerr << "No BLE adapters found." << std::endl;
             return 1;
         }
 
@@ -60,6 +119,7 @@ int main(int argc, char **argv)
         if (!CorBiReader.is_connected())
             return 1;
         SimpleBLE::ByteArray old_data = "";
+        HeartRateEstimator heartRateEstimator;
         for (;;)
         {
             try
@@ -69,12 +129,13 @@ int main(int argc, char **argv)
                 SimpleBLE::ByteArray rx_data_IR = CorBiReader.read(SERVICE_PULSEOXIMETER_UUID, CHARA_IR_UUID);
                 if (rx_data_RED != old_data)
                 {
+                    heartRateEstimator.addSamples(decode_uint16_samples(rx_data_IR));
 
                     print_byte_array_uint16(rx_data_IR);
                     std::cout << " ";
                     print_byte_array_uint16(rx_data_RED);
                     std::cout << " ";
-                    print_byte_array_int(rx_data);
+                    std::cout << std::fixed << std::setprecision(1) << heartRateEstimator.estimateBpm();
                     std::cout << std::endl;
                 }
                 old_data = rx_data_RED;
@@ -90,6 +151,18 @@ int main(int argc, char **argv)
         // std::cout << "Connected to CorBi." << std::endl;
     }
     return 0;
+}
+
+std::vector<uint16_t> decode_uint16_samples(const SimpleBLE::ByteArray &array)
+{
+    std::vector<uint16_t> samples;
+    samples.reserve(array.size() / 2);
+    for (size_t i = 0; i + 1 < array.size(); i += 2)
+    {
+        uint16_t number = (static_cast<unsigned char>(array[i]) << 8) | static_cast<unsigned char>(array[i + 1]);
+        samples.push_back(number);
+    }
+    return samples;
 }
 
 void print_byte_array_hex(SimpleBLE::ByteArray array)


### PR DESCRIPTION
## Summary
- Add a rolling-window heart-rate estimator fed by decoded IR raw samples.
- Evaluate candidate frequencies from 40 to 300 BPM and append the estimated BPM as the third output column.
- Keep the existing IR and Red raw sample columns intact.

Fixes #7.

## Validation
- cmake --build build
- Ran ./build/CorBiCore against the connected M5 and confirmed it emits IR, Red, and HeartRate columns over BLE.