### PR TITLE
Fetch SimpleBLE when not installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 .DS_Store
 
 # CMake files
+build/
 CMakeLists.txt.user
 CMakeCache.txt
 CMakeFiles

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,22 @@
 cmake_minimum_required(VERSION 3.21)
-enable_language(CXX)
+
+project(CorBiCore LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-project(CorBiCore)
-
-find_package(simpleble REQUIRED CONFIG)
+find_package(simpleble CONFIG QUIET)
+if(NOT simpleble_FOUND)
+    include(FetchContent)
+    FetchContent_Declare(
+        simpleble
+        GIT_REPOSITORY https://github.com/OpenBluetoothToolbox/SimpleBLE.git
+        GIT_TAG v0.6.1
+        SOURCE_SUBDIR simpleble
+    )
+    FetchContent_MakeAvailable(simpleble)
+endif()
 
 set(
     main.cpp


### PR DESCRIPTION
## Summary
- Make SimpleBLE optional as a preinstalled CMake package.
- Fall back to FetchContent for SimpleBLE v0.6.1 when no local package config is available.
- Ignore the local CMake build directory so generated files do not appear as untracked changes.

Fixes #2.

## Validation
- cmake -S . -B build
- cmake --build build