### PR TITLE
Improve raw IR heart-rate estimation

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -29,7 +29,7 @@ SimpleBLE::Peripheral findCorBi(SimpleBLE::Adapter adaper);
 std::vector<uint16_t> decode_uint16_samples(const SimpleBLE::ByteArray &array);
 bool setOutputMode(const std::string &input);
 void print_current_data(SimpleBLE::ByteArray ir_data, SimpleBLE::ByteArray red_data, double heart_rate);
-void write_log_data(const std::vector<uint16_t> &ir_samples, const std::vector<uint16_t> &red_samples, double heart_rate);
+void write_log_data(uint64_t timestampMs, const std::vector<uint16_t> &ir_samples, const std::vector<uint16_t> &red_samples, double heart_rate);
 std::string samples_to_csv(const std::vector<uint16_t> &samples);
 uint64_t now_ms();
 // TODO 接続周りはコールバックに変更。
@@ -50,8 +50,9 @@ std::ofstream logFile;
 class HeartRateEstimator
 {
 public:
-    void addSamples(const std::vector<uint16_t> &samples)
+    void addSamples(const std::vector<uint16_t> &samples, uint64_t timestampMs)
     {
+        updateSampleRate(samples.size(), timestampMs);
         for (uint16_t sample : samples)
         {
             processSample(sample);
@@ -63,21 +64,27 @@ public:
         if (sampleIndex < MIN_SAMPLES || quality < MIN_QUALITY)
             return 0.0;
 
+        const double spectralBpm = estimateSpectralBpm();
         const size_t samplesSinceBeat = sampleIndex - lastBeatSample;
-        if (lastBeatSample == 0 || samplesSinceBeat > MAX_STALE_SAMPLES)
-            return 0.0;
+        if (lastBeatSample == 0 || samplesSinceBeat > maxStaleSamples())
+            return spectralBpm;
 
+        if (spectralBpm > 0.0 && smoothedBpm > 0.0)
+        {
+            const double high = std::max(spectralBpm, smoothedBpm);
+            const double low = std::min(spectralBpm, smoothedBpm);
+            if (high / low > 1.35)
+                return spectralBpm;
+        }
         return smoothedBpm;
     }
 
 private:
-    static constexpr double SAMPLE_RATE_HZ = 100.0;
-    static constexpr size_t MIN_SAMPLES = 180;
+    static constexpr double DEFAULT_SAMPLE_RATE_HZ = 100.0;
+    static constexpr double SAMPLE_RATE_ALPHA = 0.15;
+    static constexpr size_t MIN_SAMPLES = 160;
     static constexpr size_t WINDOW_SIZE = 400;
     static constexpr size_t MAX_INTERVALS = 8;
-    static constexpr size_t MIN_BEAT_INTERVAL = static_cast<size_t>(SAMPLE_RATE_HZ * 60.0 / 220.0);
-    static constexpr size_t MAX_BEAT_INTERVAL = static_cast<size_t>(SAMPLE_RATE_HZ * 60.0 / 38.0);
-    static constexpr size_t MAX_STALE_SAMPLES = static_cast<size_t>(SAMPLE_RATE_HZ * 3.0);
     static constexpr int MIN_BPM = 40;
     static constexpr int MAX_BPM = 220;
     static constexpr double MIN_QUALITY = 0.16;
@@ -85,6 +92,25 @@ private:
     static constexpr double FILTER_ALPHA = 0.18;
     static constexpr double THRESHOLD_SCALE = 0.30;
     static constexpr double BPM_SMOOTHING = 0.28;
+    static constexpr double RAW_JUMP_RATIO = 0.12;
+    static constexpr double RAW_JUMP_MIN = 1200.0;
+
+    void updateSampleRate(size_t sampleCount, uint64_t timestampMs)
+    {
+        if (sampleCount == 0)
+            return;
+
+        if (lastBatchTimestampMs != 0 && timestampMs > lastBatchTimestampMs)
+        {
+            const double elapsedSeconds = static_cast<double>(timestampMs - lastBatchTimestampMs) / 1000.0;
+            const double measuredRate = static_cast<double>(sampleCount) / elapsedSeconds;
+            if (measuredRate >= 40.0 && measuredRate <= 140.0)
+            {
+                sampleRateHz = sampleRateHz + SAMPLE_RATE_ALPHA * (measuredRate - sampleRateHz);
+            }
+        }
+        lastBatchTimestampMs = timestampMs;
+    }
 
     void processSample(uint16_t raw)
     {
@@ -96,6 +122,12 @@ private:
             initialized = true;
         }
 
+        if (isContactJump(sample))
+        {
+            resetSignal(sample);
+            return;
+        }
+
         dc += DC_ALPHA * (sample - dc);
         filtered += FILTER_ALPHA * ((sample - dc) - filtered);
 
@@ -105,6 +137,30 @@ private:
 
         updateQuality();
         detectBeat(filtered);
+    }
+
+    bool isContactJump(double sample) const
+    {
+        if (!initialized || stableSamples < MIN_SAMPLES / 2)
+            return false;
+
+        const double jump = std::abs(sample - dc);
+        const double allowedJump = std::max(RAW_JUMP_MIN, std::abs(dc) * RAW_JUMP_RATIO);
+        return jump > allowedJump;
+    }
+
+    void resetSignal(double sample)
+    {
+        dc = sample;
+        filtered = 0.0;
+        previous = 0.0;
+        previousPrevious = 0.0;
+        adaptiveThreshold = 120.0;
+        quality = 0.0;
+        stableSamples = 0;
+        lastBeatSample = 0;
+        filteredWindow.clear();
+        beatIntervals.clear();
     }
 
     void updateQuality()
@@ -139,18 +195,20 @@ private:
         {
             previousPrevious = previous;
             previous = current;
+            stableSamples = filteredWindow.size();
             return;
         }
+        stableSamples = filteredWindow.size();
 
         const bool localMaximum = previous > previousPrevious && previous >= current;
         const bool strongEnough = previous > adaptiveThreshold;
         const size_t candidateSample = sampleIndex - 1;
         const size_t interval = lastBeatSample == 0 ? 0 : candidateSample - lastBeatSample;
-        const bool outsideRefractory = lastBeatSample == 0 || interval >= MIN_BEAT_INTERVAL;
+        const bool outsideRefractory = lastBeatSample == 0 || interval >= minBeatInterval();
 
         if (localMaximum && strongEnough && outsideRefractory)
         {
-            if (lastBeatSample == 0 || interval <= MAX_BEAT_INTERVAL)
+            if (lastBeatSample == 0 || interval <= maxBeatInterval())
             {
                 acceptBeat(candidateSample, interval);
             }
@@ -168,17 +226,39 @@ private:
             return;
         }
 
-        const double intervalBpm = 60.0 * SAMPLE_RATE_HZ / static_cast<double>(interval);
-        if (intervalBpm >= MIN_BPM && intervalBpm <= MAX_BPM && isConsistent(interval))
+        const double intervalBpm = 60.0 * sampleRateHz / static_cast<double>(interval);
+        const double correctedBpm = correctHarmonic(intervalBpm);
+        const size_t correctedInterval = static_cast<size_t>(std::round(60.0 * sampleRateHz / correctedBpm));
+        if (correctedBpm >= MIN_BPM && correctedBpm <= MAX_BPM && isConsistent(correctedInterval))
         {
-            beatIntervals.push_back(interval);
+            beatIntervals.push_back(correctedInterval);
             if (beatIntervals.size() > MAX_INTERVALS)
                 beatIntervals.pop_front();
 
-            const double bpm = 60.0 * SAMPLE_RATE_HZ / medianInterval();
+            const double bpm = 60.0 * sampleRateHz / medianInterval();
             smoothedBpm = smoothedBpm == 0.0 ? bpm : smoothedBpm + BPM_SMOOTHING * (bpm - smoothedBpm);
             lastBeatSample = beatSample;
         }
+    }
+
+    double correctHarmonic(double bpm) const
+    {
+        if (smoothedBpm <= 0.0)
+        {
+            if (bpm > 135.0)
+                return bpm / 2.0;
+            return bpm;
+        }
+
+        const double half = bpm / 2.0;
+        if (bpm > smoothedBpm * 1.55 && half > MIN_BPM && std::abs(half - smoothedBpm) < std::abs(bpm - smoothedBpm))
+            return half;
+
+        const double doubled = bpm * 2.0;
+        if (bpm < smoothedBpm * 0.65 && doubled < MAX_BPM && std::abs(doubled - smoothedBpm) < std::abs(bpm - smoothedBpm))
+            return doubled;
+
+        return bpm;
     }
 
     bool isConsistent(size_t interval) const
@@ -188,7 +268,7 @@ private:
 
         const double median = medianInterval();
         const double deviation = std::abs(static_cast<double>(interval) - median) / median;
-        return deviation < 0.35;
+        return deviation < 0.28;
     }
 
     double intervalConsistency() const
@@ -203,7 +283,7 @@ private:
             error += std::abs(static_cast<double>(interval) - median) / median;
         }
         error /= beatIntervals.size();
-        return clamp(1.0 - (error / 0.22), 0.0, 1.0);
+        return clamp(1.0 - (error / 0.18), 0.0, 1.0);
     }
 
     double medianInterval() const
@@ -216,14 +296,63 @@ private:
         return static_cast<double>(intervals[middle]);
     }
 
+    double estimateSpectralBpm() const
+    {
+        if (filteredWindow.size() < MIN_SAMPLES)
+            return 0.0;
+
+        const double mean = std::accumulate(filteredWindow.begin(), filteredWindow.end(), 0.0) / filteredWindow.size();
+        double bestBpm = 0.0;
+        double bestPower = 0.0;
+        for (int bpm = 45; bpm <= 140; bpm++)
+        {
+            const double frequency = static_cast<double>(bpm) / 60.0;
+            double real = 0.0;
+            double imag = 0.0;
+            for (size_t i = 0; i < filteredWindow.size(); i++)
+            {
+                const double window = 0.5 - 0.5 * std::cos((2.0 * M_PI * i) / static_cast<double>(filteredWindow.size() - 1));
+                const double sample = (filteredWindow[i] - mean) * window;
+                const double angle = 2.0 * M_PI * frequency * static_cast<double>(i) / sampleRateHz;
+                real += sample * std::cos(angle);
+                imag -= sample * std::sin(angle);
+            }
+            const double power = real * real + imag * imag;
+            if (power > bestPower)
+            {
+                bestPower = power;
+                bestBpm = static_cast<double>(bpm);
+            }
+        }
+        return bestBpm;
+    }
+
     static double clamp(double value, double minValue, double maxValue)
     {
         return std::min(maxValue, std::max(minValue, value));
     }
 
+    size_t minBeatInterval() const
+    {
+        return static_cast<size_t>(sampleRateHz * 60.0 / MAX_BPM);
+    }
+
+    size_t maxBeatInterval() const
+    {
+        return static_cast<size_t>(sampleRateHz * 60.0 / MIN_BPM);
+    }
+
+    size_t maxStaleSamples() const
+    {
+        return static_cast<size_t>(sampleRateHz * 3.0);
+    }
+
     bool initialized = false;
     size_t sampleIndex = 0;
     size_t lastBeatSample = 0;
+    size_t stableSamples = 0;
+    uint64_t lastBatchTimestampMs = 0;
+    double sampleRateHz = DEFAULT_SAMPLE_RATE_HZ;
     double dc = 0.0;
     double filtered = 0.0;
     double previous = 0.0;
@@ -347,12 +476,13 @@ int main(int argc, char **argv)
                 SimpleBLE::ByteArray rx_data_IR = CorBiReader.read(SERVICE_PULSEOXIMETER_UUID, CHARA_IR_UUID);
                 if (rx_data_RED != old_data)
                 {
+                    const uint64_t timestampMs = now_ms();
                     std::vector<uint16_t> ir_samples = decode_uint16_samples(rx_data_IR);
                     std::vector<uint16_t> red_samples = decode_uint16_samples(rx_data_RED);
-                    heartRateEstimator.addSamples(ir_samples);
+                    heartRateEstimator.addSamples(ir_samples, timestampMs);
                     const double heartRate = heartRateEstimator.estimateBpm();
                     print_current_data(rx_data_IR, rx_data_RED, heartRate);
-                    write_log_data(ir_samples, red_samples, heartRate);
+                    write_log_data(timestampMs, ir_samples, red_samples, heartRate);
                 }
                 old_data = rx_data_RED;
                 // print_byte_array_hex(rx_data);
@@ -432,12 +562,12 @@ void print_current_data(SimpleBLE::ByteArray ir_data, SimpleBLE::ByteArray red_d
     std::cout << std::endl;
 }
 
-void write_log_data(const std::vector<uint16_t> &ir_samples, const std::vector<uint16_t> &red_samples, double heart_rate)
+void write_log_data(uint64_t timestampMs, const std::vector<uint16_t> &ir_samples, const std::vector<uint16_t> &red_samples, double heart_rate)
 {
     if (!logFile.is_open())
         return;
 
-    logFile << now_ms() << "\t"
+    logFile << timestampMs << "\t"
             << std::fixed << std::setprecision(1) << heart_rate << "\t"
             << samples_to_csv(ir_samples) << "\t"
             << samples_to_csv(red_samples) << std::endl;

--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,9 @@
 #include <numeric>
 #include <atomic>
 #include <algorithm>
+#include <fstream>
+#include <chrono>
+#include <sstream>
 
 #include <simpleble/SimpleBLE.h>
 
@@ -26,6 +29,9 @@ SimpleBLE::Peripheral findCorBi(SimpleBLE::Adapter adaper);
 std::vector<uint16_t> decode_uint16_samples(const SimpleBLE::ByteArray &array);
 bool setOutputMode(const std::string &input);
 void print_current_data(SimpleBLE::ByteArray ir_data, SimpleBLE::ByteArray red_data, double heart_rate);
+void write_log_data(const std::vector<uint16_t> &ir_samples, const std::vector<uint16_t> &red_samples, double heart_rate);
+std::string samples_to_csv(const std::vector<uint16_t> &samples);
+uint64_t now_ms();
 // TODO 接続周りはコールバックに変更。
 // TODO エラーハンドリングしっかり。
 
@@ -39,6 +45,7 @@ enum class outputMode
 
 SimpleBLE::Peripheral CorBiReader;
 std::atomic<outputMode> mode{outputMode::ALL};
+std::ofstream logFile;
 
 class HeartRateEstimator
 {
@@ -263,9 +270,25 @@ int main(int argc, char **argv)
                 return 1;
             }
         }
+        else if (arg == "--log" && i + 1 < argc)
+        {
+            logFile.open(argv[++i], std::ios::out | std::ios::trunc);
+            if (!logFile.is_open())
+            {
+                std::cerr << "Failed to open log file: " << argv[i] << std::endl;
+                return 1;
+            }
+            logFile << "timestamp_ms\tbpm\tir_samples\tred_samples" << std::endl;
+            std::cerr << "Logging samples to: " << argv[i] << std::endl;
+        }
+        else if (arg == "--log")
+        {
+            std::cerr << "Usage: CorBiCore [--mode all|ir|red|ir-red] [--log path]" << std::endl;
+            return 1;
+        }
         else if (!setOutputMode(arg))
         {
-            std::cerr << "Usage: CorBiCore [--mode all|ir|red|ir-red]" << std::endl;
+            std::cerr << "Usage: CorBiCore [--mode all|ir|red|ir-red] [--log path]" << std::endl;
             return 1;
         }
     }
@@ -324,8 +347,12 @@ int main(int argc, char **argv)
                 SimpleBLE::ByteArray rx_data_IR = CorBiReader.read(SERVICE_PULSEOXIMETER_UUID, CHARA_IR_UUID);
                 if (rx_data_RED != old_data)
                 {
-                    heartRateEstimator.addSamples(decode_uint16_samples(rx_data_IR));
-                    print_current_data(rx_data_IR, rx_data_RED, heartRateEstimator.estimateBpm());
+                    std::vector<uint16_t> ir_samples = decode_uint16_samples(rx_data_IR);
+                    std::vector<uint16_t> red_samples = decode_uint16_samples(rx_data_RED);
+                    heartRateEstimator.addSamples(ir_samples);
+                    const double heartRate = heartRateEstimator.estimateBpm();
+                    print_current_data(rx_data_IR, rx_data_RED, heartRate);
+                    write_log_data(ir_samples, red_samples, heartRate);
                 }
                 old_data = rx_data_RED;
                 // print_byte_array_hex(rx_data);
@@ -403,6 +430,36 @@ void print_current_data(SimpleBLE::ByteArray ir_data, SimpleBLE::ByteArray red_d
         break;
     }
     std::cout << std::endl;
+}
+
+void write_log_data(const std::vector<uint16_t> &ir_samples, const std::vector<uint16_t> &red_samples, double heart_rate)
+{
+    if (!logFile.is_open())
+        return;
+
+    logFile << now_ms() << "\t"
+            << std::fixed << std::setprecision(1) << heart_rate << "\t"
+            << samples_to_csv(ir_samples) << "\t"
+            << samples_to_csv(red_samples) << std::endl;
+}
+
+std::string samples_to_csv(const std::vector<uint16_t> &samples)
+{
+    std::ostringstream out;
+    for (size_t i = 0; i < samples.size(); i++)
+    {
+        if (i > 0)
+            out << ",";
+        out << samples[i];
+    }
+    return out.str();
+}
+
+uint64_t now_ms()
+{
+    const auto now = std::chrono::system_clock::now();
+    const auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch());
+    return static_cast<uint64_t>(millis.count());
 }
 
 void print_byte_array_hex(SimpleBLE::ByteArray array)

--- a/main.cpp
+++ b/main.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <numeric>
 #include <atomic>
+#include <algorithm>
 
 #include <simpleble/SimpleBLE.h>
 
@@ -46,51 +47,185 @@ public:
     {
         for (uint16_t sample : samples)
         {
-            window.push_back(sample);
-            if (window.size() > WINDOW_SIZE)
-                window.pop_front();
+            processSample(sample);
         }
     }
 
     double estimateBpm() const
     {
-        if (window.size() < MIN_WINDOW_SIZE)
+        if (sampleIndex < MIN_SAMPLES || quality < MIN_QUALITY)
             return 0.0;
 
-        const double mean = std::accumulate(window.begin(), window.end(), 0.0) / window.size();
-        double best_bpm = 0.0;
-        double best_power = 0.0;
-        for (int bpm = MIN_BPM; bpm <= MAX_BPM; bpm++)
-        {
-            const double frequency = bpm / 60.0;
-            double real = 0.0;
-            double imag = 0.0;
-            for (size_t i = 0; i < window.size(); i++)
-            {
-                const double sample = static_cast<double>(window[i]) - mean;
-                const double angle = 2.0 * M_PI * frequency * static_cast<double>(i) / SAMPLE_RATE_HZ;
-                real += sample * std::cos(angle);
-                imag -= sample * std::sin(angle);
-            }
+        const size_t samplesSinceBeat = sampleIndex - lastBeatSample;
+        if (lastBeatSample == 0 || samplesSinceBeat > MAX_STALE_SAMPLES)
+            return 0.0;
 
-            const double power = real * real + imag * imag;
-            if (power > best_power)
-            {
-                best_power = power;
-                best_bpm = bpm;
-            }
-        }
-        return best_bpm;
+        return smoothedBpm;
     }
 
 private:
     static constexpr double SAMPLE_RATE_HZ = 100.0;
-    static constexpr size_t MIN_WINDOW_SIZE = 128;
-    static constexpr size_t WINDOW_SIZE = 256;
+    static constexpr size_t MIN_SAMPLES = 240;
+    static constexpr size_t WINDOW_SIZE = 400;
+    static constexpr size_t MAX_INTERVALS = 8;
+    static constexpr size_t MIN_BEAT_INTERVAL = static_cast<size_t>(SAMPLE_RATE_HZ * 60.0 / 220.0);
+    static constexpr size_t MAX_BEAT_INTERVAL = static_cast<size_t>(SAMPLE_RATE_HZ * 60.0 / 38.0);
+    static constexpr size_t MAX_STALE_SAMPLES = static_cast<size_t>(SAMPLE_RATE_HZ * 3.0);
     static constexpr int MIN_BPM = 40;
-    static constexpr int MAX_BPM = 300;
+    static constexpr int MAX_BPM = 220;
+    static constexpr double MIN_QUALITY = 0.28;
+    static constexpr double DC_ALPHA = 0.01;
+    static constexpr double FILTER_ALPHA = 0.18;
+    static constexpr double THRESHOLD_SCALE = 0.42;
+    static constexpr double BPM_SMOOTHING = 0.28;
 
-    std::deque<uint16_t> window;
+    void processSample(uint16_t raw)
+    {
+        sampleIndex++;
+        const double sample = static_cast<double>(raw);
+        if (!initialized)
+        {
+            dc = sample;
+            initialized = true;
+        }
+
+        dc += DC_ALPHA * (sample - dc);
+        filtered += FILTER_ALPHA * ((sample - dc) - filtered);
+
+        filteredWindow.push_back(filtered);
+        if (filteredWindow.size() > WINDOW_SIZE)
+            filteredWindow.pop_front();
+
+        updateQuality();
+        detectBeat(filtered);
+    }
+
+    void updateQuality()
+    {
+        if (filteredWindow.size() < MIN_SAMPLES)
+        {
+            quality = 0.0;
+            return;
+        }
+
+        double mean = std::accumulate(filteredWindow.begin(), filteredWindow.end(), 0.0) / filteredWindow.size();
+        double energy = 0.0;
+        double peak = 0.0;
+        for (double value : filteredWindow)
+        {
+            const double centered = value - mean;
+            energy += centered * centered;
+            peak = std::max(peak, std::abs(centered));
+        }
+
+        const double rms = std::sqrt(energy / filteredWindow.size());
+        const double amplitudeQuality = clamp(peak / 650.0, 0.0, 1.0);
+        const double energyQuality = clamp(rms / 260.0, 0.0, 1.0);
+        const double intervalQuality = intervalConsistency();
+        quality = clamp((amplitudeQuality * 0.45) + (energyQuality * 0.25) + (intervalQuality * 0.30), 0.0, 1.0);
+        adaptiveThreshold = std::max(80.0, rms * THRESHOLD_SCALE);
+    }
+
+    void detectBeat(double current)
+    {
+        if (filteredWindow.size() < MIN_SAMPLES)
+        {
+            previousPrevious = previous;
+            previous = current;
+            return;
+        }
+
+        const bool localMaximum = previous > previousPrevious && previous >= current;
+        const bool strongEnough = previous > adaptiveThreshold;
+        const size_t candidateSample = sampleIndex - 1;
+        const size_t interval = lastBeatSample == 0 ? 0 : candidateSample - lastBeatSample;
+        const bool outsideRefractory = lastBeatSample == 0 || interval >= MIN_BEAT_INTERVAL;
+
+        if (localMaximum && strongEnough && outsideRefractory)
+        {
+            if (lastBeatSample == 0 || interval <= MAX_BEAT_INTERVAL)
+            {
+                acceptBeat(candidateSample, interval);
+            }
+        }
+
+        previousPrevious = previous;
+        previous = current;
+    }
+
+    void acceptBeat(size_t beatSample, size_t interval)
+    {
+        if (interval == 0)
+        {
+            lastBeatSample = beatSample;
+            return;
+        }
+
+        const double intervalBpm = 60.0 * SAMPLE_RATE_HZ / static_cast<double>(interval);
+        if (intervalBpm >= MIN_BPM && intervalBpm <= MAX_BPM && isConsistent(interval))
+        {
+            beatIntervals.push_back(interval);
+            if (beatIntervals.size() > MAX_INTERVALS)
+                beatIntervals.pop_front();
+
+            const double bpm = 60.0 * SAMPLE_RATE_HZ / medianInterval();
+            smoothedBpm = smoothedBpm == 0.0 ? bpm : smoothedBpm + BPM_SMOOTHING * (bpm - smoothedBpm);
+            lastBeatSample = beatSample;
+        }
+    }
+
+    bool isConsistent(size_t interval) const
+    {
+        if (beatIntervals.size() < 3)
+            return true;
+
+        const double median = medianInterval();
+        const double deviation = std::abs(static_cast<double>(interval) - median) / median;
+        return deviation < 0.35;
+    }
+
+    double intervalConsistency() const
+    {
+        if (beatIntervals.size() < 3)
+            return 0.0;
+
+        const double median = medianInterval();
+        double error = 0.0;
+        for (size_t interval : beatIntervals)
+        {
+            error += std::abs(static_cast<double>(interval) - median) / median;
+        }
+        error /= beatIntervals.size();
+        return clamp(1.0 - (error / 0.22), 0.0, 1.0);
+    }
+
+    double medianInterval() const
+    {
+        std::vector<size_t> intervals(beatIntervals.begin(), beatIntervals.end());
+        std::sort(intervals.begin(), intervals.end());
+        const size_t middle = intervals.size() / 2;
+        if (intervals.size() % 2 == 0)
+            return (static_cast<double>(intervals[middle - 1]) + static_cast<double>(intervals[middle])) / 2.0;
+        return static_cast<double>(intervals[middle]);
+    }
+
+    static double clamp(double value, double minValue, double maxValue)
+    {
+        return std::min(maxValue, std::max(minValue, value));
+    }
+
+    bool initialized = false;
+    size_t sampleIndex = 0;
+    size_t lastBeatSample = 0;
+    double dc = 0.0;
+    double filtered = 0.0;
+    double previous = 0.0;
+    double previousPrevious = 0.0;
+    double adaptiveThreshold = 120.0;
+    double smoothedBpm = 0.0;
+    double quality = 0.0;
+    std::deque<double> filteredWindow;
+    std::deque<size_t> beatIntervals;
 };
 
 void CorBiCore_exit()

--- a/main.cpp
+++ b/main.cpp
@@ -65,7 +65,7 @@ public:
 
 private:
     static constexpr double SAMPLE_RATE_HZ = 100.0;
-    static constexpr size_t MIN_SAMPLES = 240;
+    static constexpr size_t MIN_SAMPLES = 180;
     static constexpr size_t WINDOW_SIZE = 400;
     static constexpr size_t MAX_INTERVALS = 8;
     static constexpr size_t MIN_BEAT_INTERVAL = static_cast<size_t>(SAMPLE_RATE_HZ * 60.0 / 220.0);
@@ -73,10 +73,10 @@ private:
     static constexpr size_t MAX_STALE_SAMPLES = static_cast<size_t>(SAMPLE_RATE_HZ * 3.0);
     static constexpr int MIN_BPM = 40;
     static constexpr int MAX_BPM = 220;
-    static constexpr double MIN_QUALITY = 0.28;
+    static constexpr double MIN_QUALITY = 0.16;
     static constexpr double DC_ALPHA = 0.01;
     static constexpr double FILTER_ALPHA = 0.18;
-    static constexpr double THRESHOLD_SCALE = 0.42;
+    static constexpr double THRESHOLD_SCALE = 0.30;
     static constexpr double BPM_SMOOTHING = 0.28;
 
     void processSample(uint16_t raw)
@@ -119,11 +119,11 @@ private:
         }
 
         const double rms = std::sqrt(energy / filteredWindow.size());
-        const double amplitudeQuality = clamp(peak / 650.0, 0.0, 1.0);
-        const double energyQuality = clamp(rms / 260.0, 0.0, 1.0);
+        const double amplitudeQuality = clamp(peak / 260.0, 0.0, 1.0);
+        const double energyQuality = clamp(rms / 120.0, 0.0, 1.0);
         const double intervalQuality = intervalConsistency();
-        quality = clamp((amplitudeQuality * 0.45) + (energyQuality * 0.25) + (intervalQuality * 0.30), 0.0, 1.0);
-        adaptiveThreshold = std::max(80.0, rms * THRESHOLD_SCALE);
+        quality = clamp((amplitudeQuality * 0.55) + (energyQuality * 0.30) + (intervalQuality * 0.15), 0.0, 1.0);
+        adaptiveThreshold = std::max(24.0, rms * THRESHOLD_SCALE);
     }
 
     void detectBeat(double current)

--- a/tools/analyze_log.py
+++ b/tools/analyze_log.py
@@ -145,14 +145,11 @@ def print_segments(rows: list[dict[str, str]]) -> None:
         )
 
 
-def main() -> int:
-    if len(sys.argv) != 2:
-        print("Usage: analyze_log.py path/to/corbi.tsv", file=sys.stderr)
-        return 1
-    path = Path(sys.argv[1])
+def analyze(path: Path) -> int:
     with path.open(newline="") as handle:
         rows = list(csv.DictReader(handle, delimiter="\t"))
     if not rows:
+        print(f"file: {path}")
         print("No rows found")
         return 1
 
@@ -166,6 +163,19 @@ def main() -> int:
     print(f"rough_ir_bpm={rough_bpm(ir, sample_rate):.1f}")
     print_segments(rows)
     return 0
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: analyze_log.py path/to/corbi.tsv [more.tsv ...]", file=sys.stderr)
+        return 1
+
+    status = 0
+    for index, arg in enumerate(sys.argv[1:]):
+        if index > 0:
+            print()
+        status = max(status, analyze(Path(arg)))
+    return status
 
 
 if __name__ == "__main__":

--- a/tools/analyze_log.py
+++ b/tools/analyze_log.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+import csv
+import math
+import statistics
+import sys
+from pathlib import Path
+
+
+def parse_samples(raw: str) -> list[int]:
+    return [int(part) for part in raw.split(",") if part]
+
+
+def flatten_batches(rows: list[dict[str, str]], key: str) -> list[int]:
+    samples: list[int] = []
+    for row in rows:
+        samples.extend(parse_samples(row[key]))
+    return samples
+
+
+def estimate_sample_rate(rows: list[dict[str, str]]) -> float:
+    if len(rows) < 2:
+        return 0.0
+    sample_count = 0
+    for row in rows:
+        sample_count += len(parse_samples(row["ir_samples"]))
+    start_ms = int(rows[0]["timestamp_ms"])
+    end_ms = int(rows[-1]["timestamp_ms"])
+    elapsed = (end_ms - start_ms) / 1000.0
+    if elapsed <= 0:
+        return 0.0
+    return sample_count / elapsed
+
+
+def describe(name: str, samples: list[int]) -> None:
+    if not samples:
+        print(f"{name}: no samples")
+        return
+    mean = statistics.fmean(samples)
+    minimum = min(samples)
+    maximum = max(samples)
+    span = maximum - minimum
+    stdev = statistics.pstdev(samples)
+    print(f"{name}: n={len(samples)} mean={mean:.1f} min={minimum} max={maximum} span={span} stdev={stdev:.2f}")
+
+
+def highpass(samples: list[int], alpha: float = 0.01) -> list[float]:
+    if not samples:
+        return []
+    dc = float(samples[0])
+    filtered: list[float] = []
+    smooth = 0.0
+    for sample in samples:
+        value = float(sample)
+        dc += alpha * (value - dc)
+        smooth += 0.18 * ((value - dc) - smooth)
+        filtered.append(smooth)
+    return filtered
+
+
+def rough_bpm(samples: list[int], sample_rate: float) -> float:
+    if sample_rate <= 0 or len(samples) < int(sample_rate * 4):
+        return 0.0
+    filtered = highpass(samples)
+    mean = statistics.fmean(filtered)
+    centered = [value - mean for value in filtered]
+    rms = math.sqrt(sum(value * value for value in centered) / len(centered))
+    threshold = max(24.0, rms * 0.30)
+    min_interval = int(sample_rate * 60.0 / 220.0)
+    max_interval = int(sample_rate * 60.0 / 38.0)
+    peaks: list[int] = []
+    last_peak = -max_interval
+    for i in range(1, len(centered) - 1):
+        if centered[i] <= threshold:
+            continue
+        if centered[i] <= centered[i - 1] or centered[i] < centered[i + 1]:
+            continue
+        if i - last_peak < min_interval:
+            continue
+        if i - last_peak <= max_interval or not peaks:
+            peaks.append(i)
+            last_peak = i
+    if len(peaks) < 3:
+        return 0.0
+    intervals = [b - a for a, b in zip(peaks, peaks[1:])]
+    median_interval = statistics.median(intervals)
+    return 60.0 * sample_rate / median_interval
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: analyze_log.py path/to/corbi.tsv", file=sys.stderr)
+        return 1
+    path = Path(sys.argv[1])
+    with path.open(newline="") as handle:
+        rows = list(csv.DictReader(handle, delimiter="\t"))
+    if not rows:
+        print("No rows found")
+        return 1
+
+    ir = flatten_batches(rows, "ir_samples")
+    red = flatten_batches(rows, "red_samples")
+    sample_rate = estimate_sample_rate(rows)
+    print(f"file: {path}")
+    print(f"batches={len(rows)} estimated_sample_rate={sample_rate:.2f} Hz")
+    describe("IR", ir)
+    describe("RED", red)
+    print(f"rough_ir_bpm={rough_bpm(ir, sample_rate):.1f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/analyze_log.py
+++ b/tools/analyze_log.py
@@ -86,6 +86,65 @@ def rough_bpm(samples: list[int], sample_rate: float) -> float:
     return 60.0 * sample_rate / median_interval
 
 
+def batch_mean(row: dict[str, str], key: str) -> float:
+    samples = parse_samples(row[key])
+    if not samples:
+        return 0.0
+    return statistics.fmean(samples)
+
+
+def stable_segments(rows: list[dict[str, str]]) -> list[tuple[int, int]]:
+    if not rows:
+        return []
+    means = [batch_mean(row, "ir_samples") for row in rows]
+    segments: list[tuple[int, int]] = []
+    start = 0
+    for i in range(1, len(rows)):
+        previous = means[i - 1]
+        current = means[i]
+        unstable = (
+            current < 5000
+            or abs(current - previous) > 1200
+            or abs(current - previous) / max(current, previous, 1.0) > 0.12
+        )
+        if unstable:
+            if i - start >= 8:
+                segments.append((start, i - 1))
+            start = i
+    if len(rows) - start >= 8:
+        segments.append((start, len(rows) - 1))
+    return segments
+
+
+def print_segments(rows: list[dict[str, str]]) -> None:
+    segments = stable_segments(rows)
+    if not segments:
+        print("stable_segments: none")
+        return
+
+    print("stable_segments:")
+    for index, (start, end) in enumerate(segments, start=1):
+        segment_rows = rows[start : end + 1]
+        ir = flatten_batches(segment_rows, "ir_samples")
+        red = flatten_batches(segment_rows, "red_samples")
+        sample_rate = estimate_sample_rate(segment_rows)
+        start_ms = int(segment_rows[0]["timestamp_ms"])
+        end_ms = int(segment_rows[-1]["timestamp_ms"])
+        duration = (end_ms - start_ms) / 1000.0
+        print(
+            f"  #{index}: batches={start}-{end} duration={duration:.1f}s "
+            f"sample_rate={sample_rate:.2f}Hz rough_ir_bpm={rough_bpm(ir, sample_rate):.1f}"
+        )
+        print(
+            f"      IR mean={statistics.fmean(ir):.1f} span={max(ir) - min(ir)} "
+            f"stdev={statistics.pstdev(ir):.2f}"
+        )
+        print(
+            f"      RED mean={statistics.fmean(red):.1f} span={max(red) - min(red)} "
+            f"stdev={statistics.pstdev(red):.2f}"
+        )
+
+
 def main() -> int:
     if len(sys.argv) != 2:
         print("Usage: analyze_log.py path/to/corbi.tsv", file=sys.stderr)
@@ -105,6 +164,7 @@ def main() -> int:
     describe("IR", ir)
     describe("RED", red)
     print(f"rough_ir_bpm={rough_bpm(ir, sample_rate):.1f}")
+    print_segments(rows)
     return 0
 
 


### PR DESCRIPTION
## Summary\n- Replaces the short raw frequency scan with an adaptive peak detector over DC-removed and smoothed IR samples.\n- Estimates BPM from inter-beat intervals with median smoothing and outlier rejection.\n- Adds signal-quality gating so poor/noisy input reports 0.0 instead of a confident but bogus BPM.\n\n## MAX30100 notes\n- The MAX30100 data sheet states sample rate is configurable from 50 sps to 1 ksps, but 1600us/16-bit pulse width only allows 50/100 sps.\n- Its FIFO is 16 SpO2 samples deep, so batchy delivery and occasional sample loss need to be tolerated on the PC side.\n\n## Validation\n- cmake --build build\n- Ran ./build/CorBiCore --mode all against the connected M5. Current live signal was very low amplitude, so the estimator correctly held BPM at 0.0 rather than emitting unstable values.\n\nCloses #22.